### PR TITLE
Update publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
         id: build_and_publish
         with:
           publish: "true"
-          production: ${{ github.ref == 'refs/heads/main' && 'false' }} # example of only pushing to prod DevHub when changes that triggered the job are in `main` branch
+          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} # example of only pushing to prod DevHub when changes that triggered the job are in `main` branch
           bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
           s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Allow techdocs to publish to the prod site.

Currently, it will only publish to the dev site. This change will allow the docs to be published to the prod (mvp.developer.gov.bc.ca) site.