### PR TITLE
Update mkdocs.yml to remove mermaid extension and prevent future errors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@ plugins:
 
 markdown_extensions:
   - attr_list
-  - markdown_inline_mermaid
   - md_in_html
   - mkpatcher:
       location: patcher.py


### PR DESCRIPTION
Removing `markdown_inline_mermaid` extension as it is no longer needed and has been removed from the docker image used by the `devhub-techdocs-publisher` GitHub Action. Keeping the reference will cause build failures with the latest version of the Action.