### PR TITLE
Fix "owner" value so links to team page work properly in DevHub

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: experimental
-  owner: "chefs-team"
+  owner: "bcgov/chefs-team"


### PR DESCRIPTION
Fix "owner" value so links to team page work properly in DevHub. Currently, the link to team owning the CHEFs doc is broken in Devhub. This change will fix so it displays.a team details page when clicked.