### PR TITLE
docs: update dev docs with devcontainer information

### DIFF
--- a/docs/Developer/Contributors/Local-Setup.md
+++ b/docs/Developer/Contributors/Local-Setup.md
@@ -1,7 +1,7 @@
 [Home](index) > [Developer](Developer) > [Contributors](Contributors) > **Local Setup**
 ***
 
-This document will help developers looking to install CHEFS on their local machines for testing and development. Following this documentation will set up an isolated sandbox CHEFS instance for investigation and research prior to preparing pull requests or code commits. 
+This document will help developers looking to install CHEFS on their local machines for testing and development. Following this documentation will set up an isolated sandbox CHEFS instance for investigation and research prior to preparing pull requests or code commits.
 
 <!-- **On this page:**
 * [Prerequisites](#prerequisites)
@@ -12,55 +12,27 @@ This document will help developers looking to install CHEFS on their local machi
 # Prerequisites
 <!-- **[Back to top](#top)** -->
 
-An IDIR account is required to access CHEFS. 
+An IDIR account is required to access CHEFS.
 
-Request an SSO Integration from the [Common Hosted Single Sign-on (CSS)](https://bcgov.github.io/sso-requests) page in order to obtain a resource and secret that will be used for authentication when building CHEFS. View the [detailed documentation](Pathfinder-SSO-client) about requesting the Pathfinder SSO integration. 
+Request an SSO Integration from the [Common Hosted Single Sign-on (CSS)](https://bcgov.github.io/sso-requests) page in order to obtain a resource and secret that will be used for authentication when building CHEFS. View the [detailed documentation](Pathfinder-SSO-client) about requesting the Pathfinder SSO integration.
 
-Ensure that [Docker](https://www.docker.com/get-started/) is installed on your local machine. Using Docker allows for a quick CHEFS build on your local machine however this is not how the production environment is hosted. 
+Ensure that [Docker](https://www.docker.com/get-started/) is installed and running on your local machine. Using Docker allows for a quick CHEFS build on your local machine however this is not how the production environment is hosted.
 
 # Setup
 <!-- **[Back to top](#top)** -->
 
-Start by cloning the [CHEFS source code](https://github.com/bcgov/common-hosted-form-service) onto your local machine and download `build_package.zip` linked below.
+Start by cloning the [CHEFS source code](https://github.com/bcgov/common-hosted-form-service) onto your local machine.
 
-[build_package.zip](https://github.com/bcgov/common-hosted-form-service/files/11479953/build_package.zip)
+CHEFS development takes place using a dev container. Open the cloned report in Visual Studio Code and you will be prompted to build the container.
 
-Unzip the file and move the `local.json` file such that the CHEFS directory structure follows `/common-hosted-form-service/app/config/local.json`. The `chefs_build` directory contains the directory structure and docker file for building CHEFS.
+The `.devcontainers/chefs_local` directory contains the `local.json` file for running CHEFS.
 
-Open `realm-export.json`  located at `chefs_build/docker/imports/keycloak` and search for `XXXXXXXXXXXX`. This value must match the `clientSecret` value in `local.json` so that the CHEFS API can connect to your Keycloak instance. By default, these are set to be equal and don’t need to be altered.
+> Note: Previously local development used a Keycloak container for auth. While this container and its configuration still exist, local development is configured to use the dev SSO environment. This may change in the future to use the Keycloak container and allow CHEFS to run without the BC Gov SSO.
 
-Navigate to the [CSS](https://bcgov.github.io/sso-requests) page, log in with your IDIR, and download the ‘Development’ Installation JSON from your SSO Integration. 
-
-Back in the `realm-export.json` file, search for `YYYYYYYYYYYY` and replace it with the resource you obtained from the downloaded JSON file. Search for `ZZZZZZZZZZZZ` and replace it with the secret. 
-
-All the files are now configured and you can run Keycloak and PostgreSQL. 
-
-Note that realm-export.json is configured with the SSO integration for the “Development” environment, and will only work with the resource and secret from the Development JSON. 
-
-# Build
+# Running CHEFS
 <!-- **[Back to top](#top)** -->
 
-Start Docker, open a terminal in the `/chefs_build` directory, and run the following command:
-
-    docker compose up
-
-This will start up an instance for your Keycloak and PostgreSQL containers. If you don’t want to keep the terminal open, you can append a -d to the end of the command above.
-
-Next, open a terminal in the directory `/common-hosted-form-service/app` and run the following commands:
-
-    npm install
-    npm run migrate
-    npm run seed:run
-    npm run serve
-
-This will start the process for the CHEFS API.
-
-Open another terminal in the directory `/common-hosted-form-service/app/frontend` and run the following commands:
-
-    npm install
-    npm run serve
-
-This will start the process for the CHEFS front end.
+In the sidebar select the `Build and Debug` item and in the dropdown menu select `CHEFS` and click the green arrow. This will start the API and the frontend.
 
 ***
 [Terms of Use](Terms-of-Use) | [Privacy](Privacy) | [Security](Security) | [Service Agreement](Service-Agreement) | [Accessibility](Accessibility)


### PR DESCRIPTION
We have switched from the step-by-step install to using dev container. Updated the docs to remove the manual steps.